### PR TITLE
fix: get by id in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ deno run --allow-net --unstable-kv --allow-env main.ts
 Dynamic api routing
 
 - Get /api/{collection}
+- Get /api/{collection}/id
 - Post /api/{collection}
 - Delete /api/{collection}/
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include information about the new GET API endpoint `/api/{collection}/id` under the "Dynamic api routing" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->